### PR TITLE
Pagination for GenericModel-extended entities

### DIFF
--- a/src/play/modules/GenericModelJPAPaginator.java
+++ b/src/play/modules/GenericModelJPAPaginator.java
@@ -1,0 +1,59 @@
+/**
+ *
+ * Copyright 2010, Lawrence McAlpin.
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package play.modules.paginate;
+
+import java.io.Serializable;
+import java.util.List;
+
+import play.db.jpa.GenericModel;
+import play.modules.paginate.strategy.JPARecordLocatorStrategy;
+
+/**
+ * This implementation of {@link Paginator} lets you paginate over the rows
+ * for a specified JPA entity.
+ * 
+ * @author Lawrence McAlpin
+ *
+ * @param <K>
+ * @param <T>
+ */
+public class GenericModelJPAPaginator<K, T extends GenericModel> extends Paginator<K, T> implements Serializable {
+    private static final long serialVersionUID = -2064492602195638937L;
+
+    public GenericModelJPAPaginator(Class<T> typeToken, List<K> keys) {
+        super(new JPARecordLocatorStrategy(typeToken, keys));
+    }
+
+    public GenericModelJPAPaginator(Class<T> typeToken) {
+        super(new JPARecordLocatorStrategy(typeToken));
+    }
+
+    public GenericModelJPAPaginator(Class<T> typeToken, String filter, Object... params) {
+        super(new JPARecordLocatorStrategy(typeToken, filter, params));
+    }
+
+    public GenericModelJPAPaginator<K,T> orderBy(String orderByClause) {
+        jpaStrategy().setOrderBy(orderByClause);
+        return this;
+    }
+
+    protected JPARecordLocatorStrategy jpaStrategy() {
+        return (JPARecordLocatorStrategy)getRecordLocatorStrategy();
+    }
+}

--- a/src/play/modules/GenericModelPaginator.java
+++ b/src/play/modules/GenericModelPaginator.java
@@ -1,0 +1,54 @@
+/**
+ *
+ * Copyright 2010, Lawrence McAlpin.
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package play.modules.paginate;
+
+import java.util.List;
+
+import play.db.jpa.GenericModel;
+
+/**
+ * This implementation of {@link Paginator} lets you paginate over the rows
+ * for a specified Play! framework Model.  The class must extend from the Model
+ * helper class. 
+ * 
+ * @author Lawrence McAlpin
+ *
+ * @param <T>
+ */
+public class GenericModelPaginator<T extends GenericModel> extends GenericModelJPAPaginator<Long, T> {
+    private static final long serialVersionUID = -2064492602195638937L;
+
+    public GenericModelPaginator(Class<T> typeToken) {
+        super(typeToken);
+    }
+    
+    public GenericModelPaginator(Class<T> typeToken, List<Long> keys) {
+        super(typeToken, keys);
+    }
+
+    public GenericModelPaginator(Class<T> typeToken, String filter, Object... params) {
+        super(typeToken, filter, params);
+    }
+    
+    public GenericModelPaginator<T> orderBy(String orderByClause) {
+        jpaStrategy().setOrderBy(orderByClause);
+        return this;
+    }
+
+}


### PR DESCRIPTION
Hi,
I don't know if it's the best way to achieve this but I needed pagination for my custom entities ("ids" of entities are Postgresql sequences so they extend GenericModel and not Model).
It works fine as long as custom entities' ids are correctly named.
